### PR TITLE
Find position of set bit

### DIFF
--- a/Bit Manipulation/Findpositionofsetbit.java
+++ b/Bit Manipulation/Findpositionofsetbit.java
@@ -1,0 +1,11 @@
+package DSA;
+
+public class Findpositionofsetbit {
+	 static int findPosition(int N) {
+	      
+	        return (N==0 || (N&(N-1))!=0)? -1:(int)(Math.log(N)/Math.log(2))+1;
+	    }
+	 public static void main(String ar[]) {
+		 System.out.println(findPosition(5));
+	 }
+}


### PR DESCRIPTION
Find position of set bit :-Given a number N having only one ‘1’ and all other ’0’s in its binary representation, find position of the only set bit. If there are 0 or more than 1 set bit the answer should be -1. Position of  set bit '1' should be counted starting with 1 from LSB side in binary representation of the number.

Hope this solution will help you..